### PR TITLE
Track key property collisions

### DIFF
--- a/singertools/check_tap.py
+++ b/singertools/check_tap.py
@@ -68,8 +68,8 @@ class OutputSummary(object):
     def check_key_properties(self, stream, message):
         for property in stream.key_properties:
             if message.record[property] in stream.key_property_list:
-                print('I saw a key_property collision for {} in stream {}'.format(
-                        message.record[property], stream))
+                print('I saw a duplicate primary key for {}:{} in stream {}'.format(
+                       property,  message.record[property], stream))
                 stream.num_key_property_collisions += 1
             else:
                 stream.key_property_list.append(message.record[property])
@@ -155,7 +155,7 @@ def print_summary(summary):
     print('{:7} state messages'.format(summary.num_states))
     print('')
     print('Details by stream:')
-    headers = [['stream', 'records', 'schemas', 'key property collisions']]
+    headers = [['stream', 'records', 'schemas', 'non-unique primary keys']]
     rows = [[s.name, s.num_records, s.num_schemas, s.num_key_property_collisions]
             for s in summary.streams.values()]
     data = headers + rows


### PR DESCRIPTION
Take key_properties from schema for each stream and track any duplicate primary keys. 

Potentially useful for Taps where we are injecting composite keys and need to validate uniqueness of those composite members in data.

```
Checking stdin for valid Singer-formatted data
I saw a duplicate primary key for __sdc_record_hash:30d3508b9a18e951d52cf9be6de79e7a in stream StreamAcc(name='audience_report', num_records=301, num_schemas=1, num_key_property_collisions=0)
I saw a duplicate primary key for __sdc_record_hash:cf02f2fdbd4c736f443c3b0d2ec94e2d in stream StreamAcc(name='audience_report', num_records=351, num_schemas=1, num_key_property_collisions=1)
I saw a duplicate primary key for __sdc_record_hash:30f361b935e0c6bbeb01f834fc31d5c6 in stream StreamAcc(name='audience_report', num_records=468, num_schemas=1, num_key_property_collisions=2)
I saw a duplicate primary key for __sdc_record_hash:b1200b0be994f7c3df2bef4a6d72b61e in stream StreamAcc(name='audience_report', num_records=787, num_schemas=1, num_key_property_collisions=3)
The output is valid.
It contained 1239 messages for 3 streams.

      3 schema messages
   1212 record messages
     24 state messages

Details by stream:
+------------------+---------+---------+-------------------------+
| stream           | records | schemas | non-unique primary keys |
+------------------+---------+---------+-------------------------+
| inventory_report | 379     | 1       | 0                       |
| audience_report  | 800     | 1       | 4                       |
| campaign_report  | 33      | 1       | 0                       |
+------------------+---------+---------+-------------------------+
```